### PR TITLE
Add scheme field for service

### DIFF
--- a/api/crds/appbinding.yaml
+++ b/api/crds/appbinding.yaml
@@ -318,12 +318,12 @@ spec:
               description: ClientConfig contains the information to make a connection
                 with an app
               properties:
-                CABundle:
+                caBundle:
                   description: CABundle is a PEM encoded CA bundle which will be used
                     to validate the serving certificate of this app.
                   format: byte
                   type: string
-                InsecureSkipTLSVerify:
+                insecureSkipTLSVerify:
                   description: InsecureSkipTLSVerify disables TLS certificate verification
                     when communicating with this app. This is strongly discouraged.  You
                     should use the CABundle instead.
@@ -345,6 +345,11 @@ spec:
                     - name
                     - port
                   type: array
+                scheme:
+                  description: 'Specifies which scheme to use, for example: http,
+                    https If specified, then it will applied as prefix in this format:
+                    scheme:// If not specified, then nothing will be prefixed'
+                  type: string
                 service:
                   description: ServiceReference holds a reference to Service.legacy.k8s.io
                   properties:
@@ -367,8 +372,6 @@ spec:
 
                     Attempting to use a user or basic auth e.g. "user:password@" is not allowed. Fragments ("#...") and query parameters ("?...") are not allowed, either.
                   type: string
-              required:
-              - InsecureSkipTLSVerify
             defaultParameters:
               description: "RawExtension is used to hold extensions in external versions.\n\nTo
                 use this, make a field which has RawExtension as its type in your

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1685,16 +1685,13 @@
     },
     "xyz.kmodules.custom-resources.apis.appcatalog.v1alpha1.ClientConfig": {
       "description": "ClientConfig contains the information to make a connection with an app",
-      "required": [
-        "InsecureSkipTLSVerify"
-      ],
       "properties": {
-        "CABundle": {
+        "caBundle": {
           "description": "CABundle is a PEM encoded CA bundle which will be used to validate the serving certificate of this app.",
           "type": "string",
           "format": "byte"
         },
-        "InsecureSkipTLSVerify": {
+        "insecureSkipTLSVerify": {
           "description": "InsecureSkipTLSVerify disables TLS certificate verification when communicating with this app. This is strongly discouraged.  You should use the CABundle instead.",
           "type": "boolean"
         },
@@ -1706,6 +1703,10 @@
           },
           "x-kubernetes-patch-merge-key": "port",
           "x-kubernetes-patch-strategy": "merge"
+        },
+        "scheme": {
+          "description": "Specifies which scheme to use, for example: http, https If specified, then it will applied as prefix in this format: scheme:// If not specified, then nothing will be prefixed",
+          "type": "string"
         },
         "service": {
           "description": "`service` is a reference to the service for this app. Either `service` or `url` must be specified.\n\nIf the webhook is running within the cluster, then you should use `service`.",

--- a/apis/appcatalog/v1alpha1/appbinding_types.go
+++ b/apis/appcatalog/v1alpha1/appbinding_types.go
@@ -91,16 +91,21 @@ type ClientConfig struct {
 
 	// InsecureSkipTLSVerify disables TLS certificate verification when communicating with this app.
 	// This is strongly discouraged.  You should use the CABundle instead.
-	InsecureSkipTLSVerify bool
+	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify,omitempty"`
 
 	// CABundle is a PEM encoded CA bundle which will be used to validate the serving certificate of this app.
 	// +optional
-	CABundle []byte
+	CABundle []byte `json:"caBundle,omitempty"`
 
 	// The list of ports that are exposed by this app.
 	// +patchMergeKey=port
 	// +patchStrategy=merge
 	Ports []AppPort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"port"`
+
+	// Specifies which scheme to use, for example: http, https
+	// If specified, then it will applied as prefix in this format: scheme://
+	// If not specified, then nothing will be prefixed
+	Scheme string `json:"scheme,omitempty"`
 }
 
 // ServiceReference holds a reference to Service.legacy.k8s.io

--- a/apis/appcatalog/v1alpha1/openapi_generated.go
+++ b/apis/appcatalog/v1alpha1/openapi_generated.go
@@ -13303,14 +13303,14 @@ func schema_custom_resources_apis_appcatalog_v1alpha1_ClientConfig(ref common.Re
 							Ref:         ref("kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1.ServiceReference"),
 						},
 					},
-					"InsecureSkipTLSVerify": {
+					"insecureSkipTLSVerify": {
 						SchemaProps: spec.SchemaProps{
 							Description: "InsecureSkipTLSVerify disables TLS certificate verification when communicating with this app. This is strongly discouraged.  You should use the CABundle instead.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},
-					"CABundle": {
+					"caBundle": {
 						SchemaProps: spec.SchemaProps{
 							Description: "CABundle is a PEM encoded CA bundle which will be used to validate the serving certificate of this app.",
 							Type:        []string{"string"},
@@ -13336,8 +13336,14 @@ func schema_custom_resources_apis_appcatalog_v1alpha1_ClientConfig(ref common.Re
 							},
 						},
 					},
+					"scheme": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Specifies which scheme to use, for example: http, https If specified, then it will applied as prefix in this format: scheme:// If not specified, then nothing will be prefixed",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
-				Required: []string{"InsecureSkipTLSVerify"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
Reason:
If we specify `service` in `ClientConfig`, then there's no way to know which scheme(http or https) we should use. For vault, it is required to specify the scheme.